### PR TITLE
Multiplatform dev-dll building

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "watch-client": "better-npm-run watch-client",
     "dev-dash": "webpack-dashboard -c magenta -m -- concurrently --kill-others \"npm run watch-client\" \"npm run start-dev\" \"npm run start-dev-api\"",
     "dev": "concurrently --kill-others \"npm run watch-client\" \"npm run start-dev\" \"npm run start-dev-api\"",
-    "dev-dll": "babel-node ./node_modules/.bin/webpack --colors --progress --config webpack/dll.config.js",
+    "dev-dll": "babel-node ./node_modules/webpack/bin/webpack --colors --progress --config webpack/dll.config.js",
     "test": "jest",
     "postinstall": "better-npm-run build"
   },


### PR DESCRIPTION
**Problem:** incorrect Webpack path causes building crash on Windows.

**Solution:** change a bit `dev-dll` path.